### PR TITLE
Support API about space

### DIFF
--- a/backlog.go
+++ b/backlog.go
@@ -97,6 +97,11 @@ func (api *Client) postMethod(ctx context.Context, path string, values url.Value
 	return postForm(ctx, api.httpclient, "POST", api.endpoint+path+"?apiKey="+api.apiKey, values, intf, api)
 }
 
+// put method
+func (api *Client) putMethod(ctx context.Context, path string, values url.Values, intf interface{}) error {
+	return postForm(ctx, api.httpclient, "PUT", api.endpoint+path+"?apiKey="+api.apiKey, values, intf, api)
+}
+
 // patch method
 func (api *Client) patchMethod(ctx context.Context, path string, values url.Values, intf interface{}) error {
 	return postForm(ctx, api.httpclient, "PATCH", api.endpoint+path+"?apiKey="+api.apiKey, values, intf, api)

--- a/examples/space/space.go
+++ b/examples/space/space.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/kenzo0107/backlog"
 )
@@ -19,17 +18,4 @@ func main() {
 		return
 	}
 	fmt.Printf("space key: %s, name %s\n", space.SpaceKey, space.Name)
-
-	file, _ := os.Create(filepath.Join("logo.png"))
-	if err := api.GetSpaceIcon(file); err != nil {
-		fmt.Printf("%s\n", err)
-		return
-	}
-
-	diskUsage, err := api.GetSpaceDiskUsage()
-	if err != nil {
-		fmt.Printf("on GetSpaceDiskUsage, error: %s\n", err)
-		return
-	}
-	fmt.Printf("%#v \n", *diskUsage)
 }

--- a/examples/space/space.go
+++ b/examples/space/space.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/kenzo0107/backlog"
+)
+
+func main() {
+	apiKey := os.Getenv("API_KEY")
+	baseURL := os.Getenv("BASE_URL")
+	api := backlog.New(apiKey, baseURL, backlog.OptionDebug(true))
+
+	space, err := api.GetSpace()
+	if err != nil {
+		fmt.Printf("%s\n", err)
+		return
+	}
+	fmt.Printf("space key: %s, name %s\n", space.SpaceKey, space.Name)
+
+	file, _ := os.Create(filepath.Join("logo.png"))
+	if err := api.GetSpaceIcon(file); err != nil {
+		fmt.Printf("%s\n", err)
+		return
+	}
+
+	diskUsage, err := api.GetSpaceDiskUsage()
+	if err != nil {
+		fmt.Printf("on GetSpaceDiskUsage, error: %s\n", err)
+		return
+	}
+	fmt.Printf("%#v \n", *diskUsage)
+}

--- a/logger.go
+++ b/logger.go
@@ -5,6 +5,8 @@ import (
 	"log"
 )
 
+var logFatal = log.Fatal
+
 type logger interface {
 	Output(int, string) error
 }
@@ -34,20 +36,20 @@ type internalLog struct {
 // Println replicates the behaviour of the standard logger.
 func (t internalLog) Println(v ...interface{}) {
 	if err := t.Output(2, fmt.Sprintln(v...)); err != nil {
-		log.Fatal(err)
+		logFatal(err)
 	}
 }
 
 // Printf replicates the behaviour of the standard logger.
 func (t internalLog) Printf(format string, v ...interface{}) {
 	if err := t.Output(2, fmt.Sprintf(format, v...)); err != nil {
-		log.Fatal(err)
+		logFatal(err)
 	}
 }
 
 // Print replicates the behaviour of the standard logger.
 func (t internalLog) Print(v ...interface{}) {
 	if err := t.Output(2, fmt.Sprint(v...)); err != nil {
-		log.Fatal(err)
+		logFatal(err)
 	}
 }

--- a/misc.go
+++ b/misc.go
@@ -1,6 +1,7 @@
 package backlog
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -29,20 +30,11 @@ type Error struct {
 	MoreInfo string `json:"moreInfo"`
 }
 
-// Err : error
-func (t Error) Err() error {
-	if strings.TrimSpace(t.Message) == "" {
-		return nil
-	}
-
-	return errors.New(t.Message)
-}
-
 // Errs : error
 func (t ErrorResponse) Errs() error {
 	s := []string{}
 	for _, err := range t.Errors {
-		s = append(s, err.Message)
+		s = append(s, fmt.Sprintf("code:%d message:%s moreInfo:%s", err.Code, err.Message, err.MoreInfo))
 	}
 
 	if len(s) == 0 {
@@ -220,4 +212,37 @@ func projIDOrKey(projIDOrKey interface{}) (string, error) {
 		return idOrKey, fmt.Errorf("projectIDOrKey is int or string. you specify %t", t)
 	}
 	return idOrKey, nil
+}
+
+func downloadFile(ctx context.Context, client httpClient, apiKey, downloadURL string, writer io.Writer, d debug) error {
+	if downloadURL == "" {
+		return fmt.Errorf("received empty download URL")
+	}
+
+	req, err := http.NewRequest("GET", downloadURL, &bytes.Buffer{})
+	if err != nil {
+		return err
+	}
+
+	values := url.Values{}
+	values.Add("apiKey", apiKey)
+	req.URL.RawQuery = values.Encode()
+
+	req.WithContext(ctx)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	err = checkStatusCode(resp, d)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(writer, resp.Body)
+
+	return err
 }

--- a/space.go
+++ b/space.go
@@ -1,0 +1,118 @@
+package backlog
+
+import (
+	"context"
+	"io"
+	"net/url"
+)
+
+// Space : backlog space
+type Space struct {
+	SpaceKey           string   `json:"spaceKey"`
+	Name               string   `json:"name"`
+	OwnerID            int      `json:"ownerId"`
+	Lang               string   `json:"lang"`
+	Timezone           string   `json:"timezone"`
+	ReportSendTime     string   `json:"reportSendTime"`
+	TextFormattingRule string   `json:"textFormattingRule"`
+	Created            JSONTime `json:"created"`
+	Updated            JSONTime `json:"updated"`
+}
+
+// SpaceNotification : backlog space notification
+type SpaceNotification struct {
+	Content string   `json:"content"`
+	Updated JSONTime `json:"updated"`
+}
+
+// SpaceDiskUsage : disk usage of space
+type SpaceDiskUsage struct {
+	Capacity   int                    `json:"capacity"`
+	Issue      int                    `json:"issue"`
+	Wiki       int                    `json:"wiki"`
+	File       int                    `json:"file"`
+	Subversion int                    `json:"subversion"`
+	Git        int                    `json:"git"`
+	GitLFS     int                    `json:"gitLFS"`
+	Details    []SpaceDiskUsageDetail `json:"details"`
+}
+
+// SpaceDiskUsageDetail : the detail of disk usage of a space
+type SpaceDiskUsageDetail struct {
+	ProjectID  int `json:"projectId"`
+	Issue      int `json:"issue"`
+	Wiki       int `json:"wiki"`
+	File       int `json:"file"`
+	Subversion int `json:"subversion"`
+	Git        int `json:"git"`
+	GitLFS     int `json:"gitLFS"`
+}
+
+// GetSpace returns backlog space
+func (api *Client) GetSpace() (*Space, error) {
+	return api.GetSpaceContext(context.Background())
+}
+
+// GetSpaceContext returns backlog space with context
+func (api *Client) GetSpaceContext(ctx context.Context) (*Space, error) {
+	space := Space{}
+	if err := api.getMethod(ctx, "/api/v2/space", url.Values{}, &space); err != nil {
+		return nil, err
+	}
+	return &space, nil
+}
+
+// GetSpaceIcon downloads space icon
+func (api *Client) GetSpaceIcon(writer io.Writer) error {
+	return api.GetSpaceIconContext(context.Background(), writer)
+}
+
+// GetSpaceIconContext downloads space icon with context
+func (api *Client) GetSpaceIconContext(ctx context.Context, writer io.Writer) error {
+	return downloadFile(ctx, api.httpclient, api.apiKey, api.endpoint+"/api/v2/space/image", writer, api)
+}
+
+// GetSpaceNotification returns a space notification
+func (api *Client) GetSpaceNotification() (*SpaceNotification, error) {
+	return api.GetSpaceNotificationContext(context.Background())
+}
+
+// GetSpaceNotificationContext returns a space notification with context
+func (api *Client) GetSpaceNotificationContext(ctx context.Context) (*SpaceNotification, error) {
+	spaceNotification := SpaceNotification{}
+	if err := api.getMethod(ctx, "/api/v2/space/notification", url.Values{}, &spaceNotification); err != nil {
+		return nil, err
+	}
+	return &spaceNotification, nil
+}
+
+// UpdateSpaceNotification updates a space notification
+func (api *Client) UpdateSpaceNotification(content string) (*SpaceNotification, error) {
+	return api.UpdateSpaceNotificationContext(context.Background(), content)
+}
+
+// UpdateSpaceNotificationContext updates a space notification with context
+func (api *Client) UpdateSpaceNotificationContext(ctx context.Context, content string) (*SpaceNotification, error) {
+	values := url.Values{
+		"content": {content},
+	}
+	spaceNotification := SpaceNotification{}
+	if err := api.putMethod(ctx, "/api/v2/space/notification", values, &spaceNotification); err != nil {
+		return nil, err
+	}
+	return &spaceNotification, nil
+}
+
+// GetSpaceDiskUsage returns the disk usage of a space
+func (api *Client) GetSpaceDiskUsage() (*SpaceDiskUsage, error) {
+	return api.GetSpaceDiskUsageContext(context.Background())
+}
+
+// GetSpaceDiskUsageContext returns the disk usage of a space with context
+func (api *Client) GetSpaceDiskUsageContext(ctx context.Context) (*SpaceDiskUsage, error) {
+	diskUsage := SpaceDiskUsage{}
+	if err := api.getMethod(ctx, "/api/v2/space/diskUsage", url.Values{}, &diskUsage); err != nil {
+		return nil, err
+	}
+	return &diskUsage, nil
+}

--- a/space_test.go
+++ b/space_test.go
@@ -1,0 +1,273 @@
+package backlog
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func getTestSpace() *Space {
+	return &Space{
+		SpaceKey:           "nulab",
+		Name:               "Nulab Inc.",
+		OwnerID:            1,
+		Lang:               "ja",
+		Timezone:           "Asia/Tokyo",
+		ReportSendTime:     "08:00:00",
+		TextFormattingRule: "markdown",
+		Created:            "2008-07-06T15:00:00Z",
+		Updated:            "2013-06-18T07:55:37Z",
+	}
+}
+
+func getTestSpaceNotification(content string) *SpaceNotification {
+	return &SpaceNotification{
+		Content: content,
+		Updated: JSONTime("2013-06-18T07:55:37Z"),
+	}
+}
+
+func getTestSpaceDiskUsage() *SpaceDiskUsage {
+	return &SpaceDiskUsage{
+		Capacity:   1073741824,
+		Issue:      119511,
+		Wiki:       48575,
+		File:       0,
+		Subversion: 0,
+		Git:        0,
+		GitLFS:     0,
+		Details: []SpaceDiskUsageDetail{
+			{
+				ProjectID:  1,
+				Issue:      11931,
+				Wiki:       0,
+				File:       0,
+				Subversion: 0,
+				Git:        0,
+				GitLFS:     0,
+			},
+		},
+	}
+}
+
+func errorResponse() ErrorResponse {
+	return ErrorResponse{
+		Errors: []Error{
+			{
+				Message:  "No space.",
+				Code:     6,
+				MoreInfo: "",
+			},
+		},
+	}
+}
+
+func getErrorResponse(rw http.ResponseWriter, r *http.Request) {
+	rw.WriteHeader(http.StatusInternalServerError)
+	response, _ := json.Marshal(errorResponse())
+	if _, err := rw.Write(response); err != nil {
+		fmt.Println(err)
+	}
+}
+
+func getSpace(rw http.ResponseWriter, r *http.Request) {
+	rw.Header().Set("Content-Type", "application/json")
+	response, _ := json.Marshal(getTestSpace())
+	if _, err := rw.Write(response); err != nil {
+		fmt.Println(err)
+	}
+}
+
+func getSpaceNotification(rw http.ResponseWriter, r *http.Request) {
+	rw.Header().Set("Content-Type", "application/json")
+	response, _ := json.Marshal(getTestSpaceNotification("test"))
+	if _, err := rw.Write(response); err != nil {
+		fmt.Println(err)
+	}
+}
+
+func getSpaceDiskUsage(rw http.ResponseWriter, r *http.Request) {
+	rw.Header().Set("Content-Type", "application/json")
+	response, _ := json.Marshal(getTestSpaceDiskUsage())
+	if _, err := rw.Write(response); err != nil {
+		fmt.Println(err)
+	}
+}
+
+func TestGetSpace(t *testing.T) {
+	http.HandleFunc("/api/v2/space", getSpace)
+	expected := getTestSpace()
+
+	once.Do(startServer)
+	api := New("testing-token", "http://"+serverAddr+"/")
+
+	space, err := api.GetSpace()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	if !reflect.DeepEqual(expected, space) {
+		t.Fatal(ErrIncorrectResponse)
+	}
+}
+
+func TestGetSpaceFailed(t *testing.T) {
+	http.DefaultServeMux = new(http.ServeMux)
+	http.HandleFunc("/api/v2/space", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	once.Do(startServer)
+	api := New("testing-token", "http://"+serverAddr+"/")
+
+	if _, err := api.GetSpace(); err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetSpaceErrorResponse(t *testing.T) {
+	http.DefaultServeMux = new(http.ServeMux)
+	http.HandleFunc("/api/v2/space", getErrorResponse)
+
+	once.Do(startServer)
+
+	logger := log.New(os.Stdout, "backlog: ", log.Lshortfile|log.LstdFlags)
+	api := New(
+		"testing-token",
+		"http://"+serverAddr+"/",
+		OptionDebug(true),
+		OptionHTTPClient(&http.Client{}),
+		OptionLog(logger),
+	)
+
+	api.Debugf("%s", "test")
+
+	if _, err := api.GetSpace(); err == nil {
+		log.Println("err", err)
+		t.Fatal("expected an error but got none")
+	}
+}
+
+type mockHTTPClient struct{}
+
+func (m *mockHTTPClient) Do(*http.Request) (*http.Response, error) {
+	return &http.Response{StatusCode: 200, Body: ioutil.NopCloser(bytes.NewBufferString(`OK`))}, nil
+}
+
+func TestGetSpaceIcon(t *testing.T) {
+	api := &Client{
+		endpoint:   "http://" + serverAddr + "/",
+		apiKey:     "testing-token",
+		httpclient: &mockHTTPClient{},
+	}
+
+	err := api.GetSpaceIcon(&bytes.Buffer{})
+	if err != nil {
+		log.Fatalf("Unexpected error: %s in test", err)
+	}
+}
+
+func TestGetSpaceNotification(t *testing.T) {
+	http.HandleFunc("/api/v2/space/notification", getSpaceNotification)
+	expected := getTestSpaceNotification("test")
+
+	once.Do(startServer)
+	api := New("testing-token", "http://"+serverAddr+"/")
+
+	spaceNotification, err := api.GetSpaceNotification()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	if !reflect.DeepEqual(expected, spaceNotification) {
+		t.Fatal(ErrIncorrectResponse)
+	}
+}
+
+func TestGetSpaceNotificationFailed(t *testing.T) {
+	http.DefaultServeMux = new(http.ServeMux)
+	http.HandleFunc("/api/v2/space/notification", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	once.Do(startServer)
+	api := New("testing-token", "http://"+serverAddr+"/")
+
+	if _, err := api.GetSpaceNotification(); err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestUpdateSpaceNotification(t *testing.T) {
+	http.DefaultServeMux = new(http.ServeMux)
+	http.HandleFunc("/api/v2/space/notification", getSpaceNotification)
+	expected := getTestSpaceNotification("test")
+
+	once.Do(startServer)
+	api := New("testing-token", "http://"+serverAddr+"/")
+
+	spaceNotification, err := api.UpdateSpaceNotification("test")
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	if !reflect.DeepEqual(expected, spaceNotification) {
+		t.Fatal(ErrIncorrectResponse)
+	}
+}
+
+func TestUpdateSpaceNotificationFailed(t *testing.T) {
+	http.DefaultServeMux = new(http.ServeMux)
+	http.HandleFunc("/api/v2/space/notification", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	once.Do(startServer)
+	api := New("testing-token", "http://"+serverAddr+"/")
+
+	if _, err := api.UpdateSpaceNotification("test"); err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetSpaceDiskUsage(t *testing.T) {
+	http.DefaultServeMux = new(http.ServeMux)
+	http.HandleFunc("/api/v2/space/diskUsage", getSpaceDiskUsage)
+	expected := getTestSpaceDiskUsage()
+
+	once.Do(startServer)
+	api := New("testing-token", "http://"+serverAddr+"/")
+
+	spaceNotification, err := api.GetSpaceDiskUsage()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	if !reflect.DeepEqual(expected, spaceNotification) {
+		t.Fatal(ErrIncorrectResponse)
+	}
+}
+
+func TestGetSpaceDiskUsageFailed(t *testing.T) {
+	http.DefaultServeMux = new(http.ServeMux)
+	http.HandleFunc("/api/v2/space/diskUsage", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	once.Do(startServer)
+	api := New("testing-token", "http://"+serverAddr+"/")
+
+	if _, err := api.GetSpaceDiskUsage(); err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}


### PR DESCRIPTION
Support backlog API the below:

* GET `/api/v2/space` : get the information of space
* GET `/api/v2/space/image` : download an icon of a space
* GET `/api/v2/space/notification` : get notifications of a space
* PUT `/api/v2/space/notification` : update a notification of a space
* GET `/api/v2/space/diskUsage` : get diskUsage of a space

And add unit tests for them.