### PR TITLE
Support resolution API

### DIFF
--- a/resolution.go
+++ b/resolution.go
@@ -1,0 +1,30 @@
+package backlog
+
+import "context"
+
+// Resolution : resolutions
+type Resolution struct {
+	ID   *int    `json:"id,omitempty"`
+	Name *string `json:"name,omitempty"`
+}
+
+// GetResolutions returns the list of resolutions
+func (c *Client) GetResolutions() ([]*Resolution, error) {
+	return c.GetResolutionsContext(context.Background())
+}
+
+// GetResolutionsContext returns the list of resolutions with context
+func (c *Client) GetResolutionsContext(ctx context.Context) ([]*Resolution, error) {
+	u := "/api/v2/resolutions"
+
+	req, err := c.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resolutions []*Resolution
+	if err := c.Do(ctx, req, &resolutions); err != nil {
+		return nil, err
+	}
+	return resolutions, nil
+}

--- a/resolution_test.go
+++ b/resolution_test.go
@@ -1,0 +1,53 @@
+package backlog
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/pkg/errors"
+)
+
+func getTestResolution() *Resolution {
+	return &Resolution{
+		ID:   Int(0),
+		Name: String("対応済み"),
+	}
+}
+
+func TestGetResolutions(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/resolutions", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `[{"id": 0, "name": "対応済み"}]`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetResolutions()
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := []*Resolution{getTestResolution()}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetResolutionsFailed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/resolutions", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	if _, err := client.GetResolutions(); err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}


### PR DESCRIPTION
Support backlog API the below:

* GET /api/v2/resolutions

And add unit tests for them.