### PR TITLE
Support watching API

### DIFF
--- a/watching.go
+++ b/watching.go
@@ -1,0 +1,196 @@
+package backlog
+
+import (
+	"context"
+	"fmt"
+)
+
+// Watching : -
+type Watching struct {
+	ID                  *int       `json:"id,omitempty"`
+	ResourceAlreadyRead *bool      `json:"resourceAlreadyRead,omitempty"`
+	Note                *string    `json:"note,omitempty"`
+	Type                *string    `json:"type,omitempty"`
+	Issue               *Issue     `json:"issue,omitempty"`
+	LastContentUpdated  *Timestamp `json:"lastContentUpdated,omitempty"`
+	Created             *Timestamp `json:"created,omitempty"`
+	Updated             *Timestamp `json:"updated,omitempty"`
+}
+
+// GetUserWatchings returns the list of user's watchings
+func (c *Client) GetUserWatchings(userID int) ([]*Watching, error) {
+	return c.GetUserWatchingsContext(context.Background(), userID)
+}
+
+// GetUserWatchingsContext returns the list of user's watchings with context
+func (c *Client) GetUserWatchingsContext(ctx context.Context, userID int) ([]*Watching, error) {
+	u := fmt.Sprintf("/api/v2/users/%v/watchings", userID)
+
+	req, err := c.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var watchings []*Watching
+	if err := c.Do(ctx, req, &watchings); err != nil {
+		return nil, err
+	}
+	return watchings, nil
+}
+
+// GetUserWatchingsCount returns the count of user's watchings
+func (c *Client) GetUserWatchingsCount(userID int, opts *GetUserWatchingsCountOptions) (int, error) {
+	return c.GetUserWatchingsCountContext(context.Background(), userID, opts)
+}
+
+// GetUserWatchingsCountContext returns the count of user's watchings with context
+func (c *Client) GetUserWatchingsCountContext(ctx context.Context, userID int, opts *GetUserWatchingsCountOptions) (int, error) {
+	u := fmt.Sprintf("/api/v2/users/%v/watchings/count", userID)
+
+	u, err := c.AddOptions(u, opts)
+	if err != nil {
+		return 0, err
+	}
+
+	req, err := c.NewRequest("GET", u, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	r := new(p)
+	if err := c.Do(ctx, req, &r); err != nil {
+		return 0, err
+	}
+	return r.Count, nil
+}
+
+// GetWatching returns a watching
+func (c *Client) GetWatching(watchingID int) (*Watching, error) {
+	return c.GetWatchingContext(context.Background(), watchingID)
+}
+
+// GetWatchingContext returns a watching with context
+func (c *Client) GetWatchingContext(ctx context.Context, watchingID int) (*Watching, error) {
+	u := fmt.Sprintf("/api/v2/watchings/%v", watchingID)
+
+	req, err := c.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	watching := new(Watching)
+	if err := c.Do(ctx, req, &watching); err != nil {
+		return nil, err
+	}
+	return watching, nil
+}
+
+// CreateWatching creates a watching
+func (c *Client) CreateWatching(input *CreateWatchingInput) (*Watching, error) {
+	return c.CreateWatchingContext(context.Background(), input)
+}
+
+// CreateWatchingContext creates a watching with Context
+func (c *Client) CreateWatchingContext(ctx context.Context, input *CreateWatchingInput) (*Watching, error) {
+	u := "/api/v2/watchings"
+
+	req, err := c.NewRequest("POST", u, input)
+	if err != nil {
+		return nil, err
+	}
+
+	watching := new(Watching)
+	if err := c.Do(ctx, req, &watching); err != nil {
+		return nil, err
+	}
+	return watching, nil
+}
+
+// UpdateWatching updates a watching
+func (c *Client) UpdateWatching(watchingID int, input *UpdateWatchingInput) (*Watching, error) {
+	return c.UpdateWatchingContext(context.Background(), watchingID, input)
+}
+
+// UpdateWatchingContext updates a watching with Context
+func (c *Client) UpdateWatchingContext(ctx context.Context, watchingID int, input *UpdateWatchingInput) (*Watching, error) {
+	u := fmt.Sprintf("/api/v2/watchings/%v", watchingID)
+
+	req, err := c.NewRequest("PATCH", u, input)
+	if err != nil {
+		return nil, err
+	}
+
+	watching := new(Watching)
+	if err := c.Do(ctx, req, &watching); err != nil {
+		return nil, err
+	}
+	return watching, nil
+}
+
+// DeleteWatching deletes a watching
+func (c *Client) DeleteWatching(watchingID int) (*Watching, error) {
+	return c.DeleteWatchingContext(context.Background(), watchingID)
+}
+
+// DeleteWatchingContext deletes a watching with Context
+func (c *Client) DeleteWatchingContext(ctx context.Context, watchingID int) (*Watching, error) {
+	u := fmt.Sprintf("/api/v2/watchings/%v", watchingID)
+
+	req, err := c.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	watching := new(Watching)
+	if err := c.Do(ctx, req, &watching); err != nil {
+		return nil, err
+	}
+	return watching, nil
+}
+
+// MarkAsReadWatching marks a watching as read
+func (c *Client) MarkAsReadWatching(watchingID int) error {
+	return c.MarkAsReadWatchingContext(context.Background(), watchingID)
+}
+
+// MarkAsReadWatchingContext marks a watching as read with Context
+func (c *Client) MarkAsReadWatchingContext(ctx context.Context, watchingID int) error {
+	u := fmt.Sprintf("/api/v2/watchings/%v/markAsRead", watchingID)
+
+	req, err := c.NewRequest("POST", u, nil)
+	if err != nil {
+		return err
+	}
+
+	if err := c.Do(ctx, req, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetUserWatchingsOptions specifies parameters to the GetUserWatchings method.
+type GetUserWatchingsOptions struct {
+	Order               *Order  `url:"order,omitempty"`
+	Sort                *string `url:"sort,omitempty"`
+	Count               *int    `url:"count,omitempty"`
+	Offset              *int    `url:"offset,omitempty"`
+	ResourceAlreadyRead *bool   `url:"resourceAlreadyRead,omitempty"`
+	IssueIDs            []int   `url:"issueId[],omitempty"`
+}
+
+// GetUserWatchingsCountOptions specifies parameters to the GetUserWatchingsCount method.
+type GetUserWatchingsCountOptions struct {
+	ResourceAlreadyRead *bool `url:"resourceAlreadyRead,omitempty"`
+	AlreadyRead         *bool `url:"alreadyRead,omitempty"`
+}
+
+// CreateWatchingInput specifies parameters to the CreateWatching method.
+type CreateWatchingInput struct {
+	IssueIDOrKey *string `json:"issueIdOrKey"`
+	Note         *string `json:"note,omitempty"`
+}
+
+// UpdateWatchingInput specifies parameters to the UpdateWatching method.
+type UpdateWatchingInput struct {
+	Note *string `json:"note,omitempty"`
+}

--- a/watching_test.go
+++ b/watching_test.go
@@ -1,0 +1,285 @@
+package backlog
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/pkg/errors"
+)
+
+var testJSONUserWatching string = fmt.Sprintf(`{
+	"id": 1,
+	"resourceAlreadyRead": true,
+	"note": "This is a note for the watching issue.",
+	"type": "issue",
+	"issue": %v,
+	"lastContentUpdated":"2006-01-02T15:04:05Z",
+	"created": "2006-01-02T15:04:05Z",
+	"updated": "2006-01-02T15:04:05Z"
+}`, testJSONIssue)
+
+func getTestWatching() *Watching {
+	return &Watching{
+		ID:                  Int(1),
+		ResourceAlreadyRead: Bool(true),
+		Note:                String("This is a note for the watching issue."),
+		Type:                String("issue"),
+		Issue:               getTestIssuesWithID(1),
+		LastContentUpdated:  &Timestamp{referenceTime},
+		Created:             &Timestamp{referenceTime},
+		Updated:             &Timestamp{referenceTime},
+	}
+}
+
+func TestGetUserWatchings(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/users/1/watchings", func(w http.ResponseWriter, r *http.Request) {
+		j := fmt.Sprintf("[%s]", testJSONUserWatching)
+		if _, err := fmt.Fprint(w, j); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetUserWatchings(1)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := []*Watching{getTestWatching()}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetUserWatchingsFailed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/users/1/watchings", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	if _, err := client.GetUserWatchings(1); err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetUserWatchingsCount(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/users/1/watchings/count", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"count": 138
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetUserWatchingsCount(1, &GetUserWatchingsCountOptions{})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := 138
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetUserWatchingsCountFailed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/users/1/watchings/count", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	if _, err := client.GetUserWatchingsCount(1, &GetUserWatchingsCountOptions{}); err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetWatching(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/watchings/1", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, testJSONUserWatching); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetWatching(1)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := getTestWatching()
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetWatchingFailed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/watchings/1", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	if _, err := client.GetWatching(1); err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestCreateWatching(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/watchings", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, testJSONUserWatching); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.CreateWatching(&CreateWatchingInput{
+		IssueIDOrKey: String("BLG-1"),
+		Note:         String("This is a note for the watching issue."),
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := getTestWatching()
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestCreateWatchingFailed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/watchings", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	if _, err := client.CreateWatching(&CreateWatchingInput{
+		IssueIDOrKey: String("BLG-1"),
+		Note:         String("This is a note for the watching issue."),
+	}); err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestUpdateWatching(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/watchings/1", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, testJSONUserWatching); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.UpdateWatching(1, &UpdateWatchingInput{
+		Note: String("This is a note for the watching issue."),
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := getTestWatching()
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestUpdateWatchingFailed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/watchings/1", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	if _, err := client.UpdateWatching(1, &UpdateWatchingInput{
+		Note: String("This is a note for the watching issue."),
+	}); err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestDeleteWatching(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/watchings/1", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, testJSONUserWatching); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.DeleteWatching(1)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := getTestWatching()
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestDeleteWatchingFailed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/watchings/1", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	if _, err := client.DeleteWatching(1); err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestMarkAsReadWatching(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/watchings/1/markAsRead", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	if err := client.MarkAsReadWatching(1); err != nil {
+		log.Fatalf("Unexpected error: %s in test", err)
+	}
+}
+
+func TestMarkAsReadWatchingFailed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("watchings/1/markAsRead", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	if err := client.MarkAsReadWatching(1); err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}


### PR DESCRIPTION
Support backlog API the below:

* GET		/api/v2/users/:userId/watchings
* GET		/api/v2/users/:userId/watchings/count
* GET		/api/v2/watchings/:watchingId
* POST		/api/v2/watchings
* PATCH		/api/v2/watchings/:watchingId
* DELETE	/api/v2/watchings/:watchingId
* POST		/api/v2/watchings/:watchingId/markAsRead

And add unit tests for them.