### PR TITLE
Support project API

### DIFF
--- a/activity.go
+++ b/activity.go
@@ -1,0 +1,87 @@
+package backlog
+
+import (
+	"context"
+	"fmt"
+)
+
+// Activity : activity
+type Activity struct {
+	ID            *int            `json:"id,omitempty"` // User.ID
+	Project       *Project        `json:"project,omitempty"`
+	Type          *int            `json:"type,omitempty"`
+	Content       *Content        `json:"content,omitempty"`
+	Notifications []*Notification `json:"notifications,omitempty"`
+	CreatedUser   *User           `json:"createdUser,omitempty"`
+	Created       *Timestamp      `json:"created,omitempty"`
+}
+
+// GetUserActivities returns the list of a user's activities
+func (c *Client) GetUserActivities(id int, opts *GetUserActivitiesOptions) ([]*Activity, error) {
+	return c.GetUserActivitiesContext(context.Background(), id, opts)
+}
+
+// GetUserActivitiesContext returns the list of a user's activities with context
+func (c *Client) GetUserActivitiesContext(ctx context.Context, id int, opts *GetUserActivitiesOptions) ([]*Activity, error) {
+	u := fmt.Sprintf("/api/v2/users/%v/activities", id)
+
+	u, err := c.AddOptions(u, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := c.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var activities []*Activity
+	if err := c.Do(ctx, req, &activities); err != nil {
+		return nil, err
+	}
+	return activities, nil
+}
+
+// GetProjectActivities returns the list of a project's activities
+func (c *Client) GetProjectActivities(projectIDOrKey interface{}, opts *GetProjectActivitiesOptions) ([]*Activity, error) {
+	return c.GetProjectActivitiesContext(context.Background(), projectIDOrKey, opts)
+}
+
+// GetProjectActivitiesContext returns the list of a project's activities with context
+func (c *Client) GetProjectActivitiesContext(ctx context.Context, projectIDOrKey interface{}, opts *GetProjectActivitiesOptions) ([]*Activity, error) {
+	u := fmt.Sprintf("/api/v2/projects/%v/activities", projectIDOrKey)
+
+	u, err := c.AddOptions(u, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := c.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var activities []*Activity
+	if err := c.Do(ctx, req, &activities); err != nil {
+		return nil, err
+	}
+	return activities, nil
+}
+
+// GetUserActivitiesOptions specifies parameters to the GetUserActivities method.
+type GetUserActivitiesOptions struct {
+	ActivityTypeIDs []int `url:"activityTypeId[],omitempty"`
+	MinID           *int  `url:"minId,omitempty"`
+	MaxID           *int  `url:"maxId,omitempty"`
+	Count           *int  `url:"count,omitempty"`
+	Order           Order `url:"order,omitempty"`
+}
+
+// GetProjectActivitiesOptions specifies parameters to the GetProjectActivities method.
+type GetProjectActivitiesOptions struct {
+	ActivityTypeIDs []int `url:"activityTypeId[],omitempty"`
+	MinID           *int  `url:"minId,omitempty"`
+	MaxID           *int  `url:"maxId,omitempty"`
+	Count           *int  `url:"count,omitempty"`
+	Order           Order `url:"order,omitempty"`
+}

--- a/activity_test.go
+++ b/activity_test.go
@@ -1,0 +1,167 @@
+package backlog
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/pkg/errors"
+)
+
+const testJSONActivity string = `{
+	"id": 1,
+	"project": {
+		"id": 92,
+		"projectKey": "SUB",
+		"name": "サブタスク",
+		"chartEnabled": true,
+		"subtaskingEnabled": true,
+		"projectLeaderCanEditProjectLeader": false,
+		"textFormattingRule": "",
+		"archived": false,
+		"displayOrder": 0
+	},
+	"type": 2,
+	"content": {
+		"id": 4809,
+		"key_id": 121,
+		"summary": "コメント",
+		"description": "",
+		"comment": {
+			"id": 7237,
+			"content": ""
+		},
+		"changes": [
+			{
+				"field": "milestone",
+				"new_value": " R2014-07-23",
+				"old_value": "",
+				"type": "standard"
+			},
+			{
+				"field": "status",
+				"new_value": "4",
+				"old_value": "1",
+				"type": "standard"
+			}
+		]
+	},
+	"notifications": [
+		{
+			"id": 25,
+			"alreadyRead": false,
+			"reason": 2,
+			"user": {
+				"id": 5686,
+				"userId": "takada",
+				"name": "takada",
+				"roleType": 2,
+				"lang": "ja",
+				"mailAddress": "takada@nulab.example"
+			},
+			"resourceAlreadyRead": false
+		}
+	],
+	"createdUser": {
+		"id": 1,
+		"userId": "admin",
+		"name": "admin",
+		"roleType": 1,
+		"lang": "ja",
+		"mailAddress": "eguchi@nulab.example"
+	},
+	"created": "2006-01-02T15:04:05Z"
+}`
+
+func TestGetUserActivities(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/users/1/activities", func(w http.ResponseWriter, r *http.Request) {
+		j := fmt.Sprintf("[%s]", testJSONActivity)
+		if _, err := fmt.Fprint(w, j); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	input := &GetUserActivitiesOptions{
+		ActivityTypeIDs: []int{1, 2, 3},
+		MinID:           Int(1),
+		MaxID:           Int(10),
+		Count:           Int(20),
+		Order:           OrderAsc,
+	}
+	activities, err := client.GetUserActivities(1, input)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := []*Activity{getTestActivity()}
+
+	if !reflect.DeepEqual(want, activities) {
+		t.Fatal(ErrIncorrectResponse)
+	}
+}
+
+func TestGetUserActivitiesFailed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/users/1/activities", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	input := &GetUserActivitiesOptions{}
+	if _, err := client.GetUserActivities(1, input); err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetProjectActivities(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/projects/SRE/activities", func(w http.ResponseWriter, r *http.Request) {
+		j := fmt.Sprintf("[%s]", testJSONActivity)
+		if _, err := fmt.Fprint(w, j); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetProjectActivities("SRE", &GetProjectActivitiesOptions{})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := []*Activity{getTestActivity()}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetProjectActivitiesFailed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/projects/SRE/activities", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	if _, err := client.GetProjectActivities("SRE", &GetProjectActivitiesOptions{}); err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetProjectActivitiesInvalidProjectKey(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	_, err := client.GetProjectActivities("%", &GetProjectActivitiesOptions{})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}

--- a/project.go
+++ b/project.go
@@ -3,6 +3,7 @@ package backlog
 import (
 	"context"
 	"fmt"
+	"io"
 )
 
 // Project : project
@@ -25,6 +26,47 @@ type Status struct {
 	Name         *string `json:"name,omitempty"`
 	Color        *string `json:"color,omitempty"`
 	DisplayOrder *int    `json:"displayOrder,omitempty"`
+}
+
+// ProjectDiskUsage : disk usage of project
+type ProjectDiskUsage struct {
+	ProjectID  *int `json:"projectId,omitempty"`
+	Issue      *int `json:"issue,omitempty"`
+	Wiki       *int `json:"wiki,omitempty"`
+	File       *int `json:"file,omitempty"`
+	Subversion *int `json:"subversion,omitempty"`
+	Git        *int `json:"git,omitempty"`
+	GitLFS     *int `json:"gitLFS,omitempty"`
+}
+
+// RecentlyViewedProject : recently viewed project
+type RecentlyViewedProject struct {
+	Project *Project   `json:"project"`
+	Updated *Timestamp `json:"updated"`
+}
+
+// GetMyRecentlyViewedProjects returns the list of projects I recently viewed
+func (c *Client) GetMyRecentlyViewedProjects(opts *GetMyRecentlyViewedProjectsOptions) ([]*RecentlyViewedProject, error) {
+	return c.GetMyRecentlyViewedProjectsContext(context.Background(), opts)
+}
+
+// GetMyRecentlyViewedProjectsContext returns the list of projects I recently viewed with context
+func (c *Client) GetMyRecentlyViewedProjectsContext(ctx context.Context, opts *GetMyRecentlyViewedProjectsOptions) ([]*RecentlyViewedProject, error) {
+	u, err := c.AddOptions("/api/v2/users/myself/recentlyViewedProjects", opts)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := c.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var recentlyViewedProjects []*RecentlyViewedProject
+	if err := c.Do(ctx, req, &recentlyViewedProjects); err != nil {
+		return nil, err
+	}
+	return recentlyViewedProjects, nil
 }
 
 // GetProjects returns the list of projects
@@ -72,13 +114,13 @@ func (c *Client) GetProjectContext(ctx context.Context, projectIDOrKey interface
 	return project, nil
 }
 
-// GetProjectStatuses returns the statuses of a project
-func (c *Client) GetProjectStatuses(projectIDOrKey interface{}) ([]*Status, error) {
-	return c.GetProjectStatusesContext(context.Background(), projectIDOrKey)
+// GetStatuses returns the statuses of a project
+func (c *Client) GetStatuses(projectIDOrKey interface{}) ([]*Status, error) {
+	return c.GetStatusesContext(context.Background(), projectIDOrKey)
 }
 
-// GetProjectStatusesContext returns the statuses of a project with context
-func (c *Client) GetProjectStatusesContext(ctx context.Context, projectIDOrKey interface{}) ([]*Status, error) {
+// GetStatusesContext returns the statuses of a project with context
+func (c *Client) GetStatusesContext(ctx context.Context, projectIDOrKey interface{}) ([]*Status, error) {
 	u := fmt.Sprintf("/api/v2/projects/%v/statuses", projectIDOrKey)
 
 	req, err := c.NewRequest("GET", u, nil)
@@ -156,6 +198,269 @@ func (c *Client) DeleteProjectContext(ctx context.Context, projectIDOrKey interf
 	return project, nil
 }
 
+// GetProjectIcon downloads project icon
+func (c *Client) GetProjectIcon(projectIDOrKey interface{}, writer io.Writer) error {
+	return c.GetProjectIconContext(context.Background(), projectIDOrKey, writer)
+}
+
+// GetProjectIconContext downloads project icon with context
+func (c *Client) GetProjectIconContext(ctx context.Context, projectIDOrKey interface{}, writer io.Writer) error {
+	u := fmt.Sprintf("/api/v2/projects/%v/image", projectIDOrKey)
+
+	req, err := c.NewRequest("GET", u, nil)
+	if err != nil {
+		return err
+	}
+
+	if err := c.Do(ctx, req, writer); err != nil {
+		return err
+	}
+	return nil
+}
+
+// AddProjectUser adds a user to a project
+func (c *Client) AddProjectUser(projectIDOrKey interface{}, input *AddProjectUserInput) (*User, error) {
+	return c.AddProjectUserContext(context.Background(), projectIDOrKey, input)
+}
+
+// AddProjectUserContext adds a user to a project with context
+func (c *Client) AddProjectUserContext(ctx context.Context, projectIDOrKey interface{}, input *AddProjectUserInput) (*User, error) {
+	u := fmt.Sprintf("/api/v2/projects/%v/users", projectIDOrKey)
+
+	req, err := c.NewRequest("POST", u, input)
+	if err != nil {
+		return nil, err
+	}
+
+	var user *User
+	if err := c.Do(ctx, req, &user); err != nil {
+		return nil, err
+	}
+	return user, nil
+}
+
+// GetProjectUsers returns the list of users in a project
+func (c *Client) GetProjectUsers(projectIDOrKey interface{}, opts *GetProjectUsersOptions) ([]*User, error) {
+	return c.GetProjectUsersContext(context.Background(), projectIDOrKey, opts)
+}
+
+// GetProjectUsersContext returns the list of users in a project with context
+func (c *Client) GetProjectUsersContext(ctx context.Context, projectIDOrKey interface{}, opts *GetProjectUsersOptions) ([]*User, error) {
+	u := fmt.Sprintf("/api/v2/projects/%v/users", projectIDOrKey)
+
+	u, err := c.AddOptions(u, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := c.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var users []*User
+	if err := c.Do(ctx, req, &users); err != nil {
+		return nil, err
+	}
+	return users, nil
+}
+
+// DeleteProjectUser deletes a user in a project
+func (c *Client) DeleteProjectUser(projectIDOrKey interface{}, input *DeleteProjectUserInput) (*User, error) {
+	return c.DeleteProjectUserContext(context.Background(), projectIDOrKey, input)
+}
+
+// DeleteProjectUserContext deletes a user in a project with Context
+func (c *Client) DeleteProjectUserContext(ctx context.Context, projectIDOrKey interface{}, input *DeleteProjectUserInput) (*User, error) {
+	u := fmt.Sprintf("/api/v2/projects/%v/users", projectIDOrKey)
+
+	req, err := c.NewRequest("DELETE", u, input)
+	if err != nil {
+		return nil, err
+	}
+
+	user := new(User)
+	if err := c.Do(ctx, req, &user); err != nil {
+		return nil, err
+	}
+	return user, nil
+}
+
+// AddProjectAdministrator adds an administrator in a project
+func (c *Client) AddProjectAdministrator(projectIDOrKey interface{}, input *AddProjectAdministratorInput) (*User, error) {
+	return c.AddProjectAdministratorContext(context.Background(), projectIDOrKey, input)
+}
+
+// AddProjectAdministratorContext adds an administrator in a project with context
+func (c *Client) AddProjectAdministratorContext(ctx context.Context, projectIDOrKey interface{}, input *AddProjectAdministratorInput) (*User, error) {
+	u := fmt.Sprintf("/api/v2/projects/%v/administrators", projectIDOrKey)
+
+	req, err := c.NewRequest("POST", u, input)
+	if err != nil {
+		return nil, err
+	}
+
+	user := new(User)
+	if err := c.Do(ctx, req, &user); err != nil {
+		return nil, err
+	}
+	return user, nil
+}
+
+// GetProjectAdministrators returns the list of administrators in a project
+func (c *Client) GetProjectAdministrators(projectIDOrKey interface{}) ([]*User, error) {
+	return c.GetProjectAdministratorsContext(context.Background(), projectIDOrKey)
+}
+
+// GetProjectAdministratorsContext returns the list of administrators in a project with context
+func (c *Client) GetProjectAdministratorsContext(ctx context.Context, projectIDOrKey interface{}) ([]*User, error) {
+	u := fmt.Sprintf("/api/v2/projects/%v/administrators", projectIDOrKey)
+
+	req, err := c.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var users []*User
+	if err := c.Do(ctx, req, &users); err != nil {
+		return nil, err
+	}
+	return users, nil
+}
+
+// DeleteProjectAdministrator deletes a administrator in a project
+func (c *Client) DeleteProjectAdministrator(projectIDOrKey interface{}, input *DeleteProjectAdministratorInput) (*User, error) {
+	return c.DeleteProjectAdministratorContext(context.Background(), projectIDOrKey, input)
+}
+
+// DeleteProjectAdministratorContext deletes a administrator in a project with Context
+func (c *Client) DeleteProjectAdministratorContext(ctx context.Context, projectIDOrKey interface{}, input *DeleteProjectAdministratorInput) (*User, error) {
+	u := fmt.Sprintf("/api/v2/projects/%v/administrators", projectIDOrKey)
+
+	req, err := c.NewRequest("DELETE", u, input)
+	if err != nil {
+		return nil, err
+	}
+
+	user := new(User)
+	if err := c.Do(ctx, req, &user); err != nil {
+		return nil, err
+	}
+	return user, nil
+}
+
+// CreateStatus creates a status
+func (c *Client) CreateStatus(projectIDOrKey interface{}, input *CreateStatusInput) (*Status, error) {
+	return c.CreateStatusContext(context.Background(), projectIDOrKey, input)
+}
+
+// CreateStatusContext creates a status
+func (c *Client) CreateStatusContext(ctx context.Context, projectIDOrKey interface{}, input *CreateStatusInput) (*Status, error) {
+	u := fmt.Sprintf("/api/v2/projects/%v/statuses", projectIDOrKey)
+
+	req, err := c.NewRequest("POST", u, input)
+	if err != nil {
+		return nil, err
+	}
+
+	status := new(Status)
+	if err := c.Do(ctx, req, &status); err != nil {
+		return nil, err
+	}
+	return status, nil
+}
+
+// UpdateStatus updates a status
+func (c *Client) UpdateStatus(projectIDOrKey interface{}, statusID int, input *UpdateStatusInput) (*Status, error) {
+	return c.UpdateStatusContext(context.Background(), projectIDOrKey, statusID, input)
+}
+
+// UpdateStatusContext updates a status
+func (c *Client) UpdateStatusContext(ctx context.Context, projectIDOrKey interface{}, statusID int, input *UpdateStatusInput) (*Status, error) {
+	u := fmt.Sprintf("/api/v2/projects/%v/statuses/%v", projectIDOrKey, statusID)
+
+	req, err := c.NewRequest("PATCH", u, input)
+	if err != nil {
+		return nil, err
+	}
+
+	status := new(Status)
+	if err := c.Do(ctx, req, &status); err != nil {
+		return nil, err
+	}
+	return status, nil
+}
+
+// DeleteStatus deletes a status
+func (c *Client) DeleteStatus(projectIDOrKey interface{}, statusID int, input *DeleteStatusInput) (*Status, error) {
+	return c.DeleteStatusContext(context.Background(), projectIDOrKey, statusID, input)
+}
+
+// DeleteStatusContext deletes a status
+func (c *Client) DeleteStatusContext(ctx context.Context, projectIDOrKey interface{}, statusID int, input *DeleteStatusInput) (*Status, error) {
+	u := fmt.Sprintf("/api/v2/projects/%v/statuses/%v", projectIDOrKey, statusID)
+
+	req, err := c.NewRequest("DELETE", u, input)
+	if err != nil {
+		return nil, err
+	}
+
+	status := new(Status)
+	if err := c.Do(ctx, req, &status); err != nil {
+		return nil, err
+	}
+	return status, nil
+}
+
+// SortStatuses sorts the list of statuses
+func (c *Client) SortStatuses(projectIDOrKey interface{}, input *SortStatusesInput) ([]*Status, error) {
+	return c.SortStatusesContext(context.Background(), projectIDOrKey, input)
+}
+
+// SortStatusesContext sorts the list of statuses with context
+func (c *Client) SortStatusesContext(ctx context.Context, projectIDOrKey interface{}, input *SortStatusesInput) ([]*Status, error) {
+	u := fmt.Sprintf("/api/v2/projects/%v/statuses/updateDisplayOrder", projectIDOrKey)
+
+	req, err := c.NewRequest("PATCH", u, input)
+	if err != nil {
+		return nil, err
+	}
+
+	statuses := []*Status{}
+	if err := c.Do(ctx, req, &statuses); err != nil {
+		return nil, err
+	}
+	return statuses, nil
+}
+
+// GetProjectDiskUsage returns disk usage of a project
+func (c *Client) GetProjectDiskUsage(projectIDOrKey interface{}) (*ProjectDiskUsage, error) {
+	return c.GetProjectDiskUsageContext(context.Background(), projectIDOrKey)
+}
+
+// GetProjectDiskUsageContext returns the list of administrators in a project with context
+func (c *Client) GetProjectDiskUsageContext(ctx context.Context, projectIDOrKey interface{}) (*ProjectDiskUsage, error) {
+	u := fmt.Sprintf("/api/v2/projects/%v/diskUsage", projectIDOrKey)
+
+	req, err := c.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	projectDiskUsage := new(ProjectDiskUsage)
+	if err := c.Do(ctx, req, &projectDiskUsage); err != nil {
+		return nil, err
+	}
+	return projectDiskUsage, nil
+}
+
+// GetMyRecentlyViewedProjectsOptions specifies parameters to the GetMyRecentlyViewedProject method.
+type GetMyRecentlyViewedProjectsOptions struct {
+	Order  Order `url:"order,omitempty"`
+	Offset *int  `url:"offset,omitempty"`
+	Count  *int  `url:"count,omitempty"`
+}
+
 // GetProjectsOptions contains all the parameters necessary (including the optional ones) for a GetProjects() request.
 type GetProjectsOptions struct {
 	Archived *bool `url:"archived"`
@@ -181,4 +486,51 @@ type UpdateProjectInput struct {
 	ProjectLeaderCanEditProjectLeader *bool   `json:"projectLeaderCanEditProjectLeader,omitempty"`
 	TextFormattingRule                *string `json:"textFormattingRule,omitempty"`
 	Archived                          *bool   `json:"archived,omitempty"`
+}
+
+// AddProjectUserInput specifies parameters to the AddProjectUser method.
+type AddProjectUserInput struct {
+	UserID *int `json:"userId"`
+}
+
+// GetProjectUsersOptions specifies parameters to the GetProjectUsers method.
+type GetProjectUsersOptions struct {
+	ExcludeGroupMembers *bool `url:"excludeGroupMembers,omitempty"`
+}
+
+// DeleteProjectUserInput specifies parameters to the DeleteProjectUser method.
+type DeleteProjectUserInput struct {
+	UserID *int `json:"userId"`
+}
+
+// AddProjectAdministratorInput specifies parameters to the AddProjectAdministrator method.
+type AddProjectAdministratorInput struct {
+	UserID *int `json:"userId"`
+}
+
+// DeleteProjectAdministratorInput specifies parameters to the DeleteProjectAdministrator method.
+type DeleteProjectAdministratorInput struct {
+	UserID *int `json:"userId"`
+}
+
+// CreateStatusInput specifies parameters to the CreateStatus method.
+type CreateStatusInput struct {
+	Name  *string `json:"name"`
+	Color *string `json:"color"`
+}
+
+// UpdateStatusInput specifies parameters to the UpdateStatus method.
+type UpdateStatusInput struct {
+	Name  *string `json:"name,omitempty"`
+	Color *string `json:"color,omitempty"`
+}
+
+// DeleteStatusInput specifies parameters to the DeleteStatus method.
+type DeleteStatusInput struct {
+	SubstituteStatusID *int `json:"substituteStatusId"`
+}
+
+// SortStatusesInput specifies parameters to the SortStatuses method.
+type SortStatusesInput struct {
+	StatusIDs []int `json:"statusId,omitempty"`
 }

--- a/project_test.go
+++ b/project_test.go
@@ -584,8 +584,7 @@ func TestDeleteProjectUser(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/projects/SRE/users", func(w http.ResponseWriter, r *http.Request) {
-		j := fmt.Sprintf("%s", testJSONUser)
-		if _, err := fmt.Fprint(w, j); err != nil {
+		if _, err := fmt.Fprint(w, testJSONUser); err != nil {
 			t.Fatal(err)
 		}
 	})

--- a/project_test.go
+++ b/project_test.go
@@ -1,10 +1,15 @@
 package backlog
 
 import (
+	"bytes"
 	"fmt"
+	"log"
 	"net/http"
 	"reflect"
 	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/pkg/errors"
 )
 
 const testJSONProject string = `{
@@ -49,6 +54,56 @@ func getTestProjectStatus() *Status {
 	}
 }
 
+func getRecentlyViewedProject() *RecentlyViewedProject {
+	return &RecentlyViewedProject{
+		Project: getTestProject(),
+		Updated: &Timestamp{referenceTime},
+	}
+}
+
+func TestGetMyRecentlyViewedProjects(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/users/myself/recentlyViewedProjects", func(w http.ResponseWriter, r *http.Request) {
+		j := fmt.Sprintf(`[{
+			"project": %v,
+			"updated": "2006-01-02T15:04:05Z"
+		}]`, testJSONProject)
+		if _, err := fmt.Fprint(w, j); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetMyRecentlyViewedProjects(&GetMyRecentlyViewedProjectsOptions{})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := []*RecentlyViewedProject{getRecentlyViewedProject()}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse)
+	}
+}
+
+func TestGetMyRecentlyViewedProjectsFailed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/users/myself/recentlyViewedProjects", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetMyRecentlyViewedProjects(&GetMyRecentlyViewedProjectsOptions{
+		Order: Order("asc"),
+		Count: Int(30),
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
 func TestGetProjects(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
@@ -60,11 +115,11 @@ func TestGetProjects(t *testing.T) {
 		}
 	})
 
-	input := &GetProjectsOptions{
+	opts := &GetProjectsOptions{
 		All:      Bool(true),
 		Archived: Bool(false),
 	}
-	projects, err := client.GetProjects(input)
+	projects, err := client.GetProjects(opts)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 		return
@@ -84,8 +139,8 @@ func TestGetProjectsFailed(t *testing.T) {
 		w.WriteHeader(http.StatusInternalServerError)
 	})
 
-	input := &GetProjectsOptions{}
-	_, err := client.GetProjects(input)
+	opts := &GetProjectsOptions{}
+	_, err := client.GetProjects(opts)
 	if err == nil {
 		t.Fatal("expected an error but got none")
 	}
@@ -136,7 +191,7 @@ func TestGetProjectWithInvalidProjectIDOrKeyFailed(t *testing.T) {
 	}
 }
 
-func TestGetProjectStatuses(t *testing.T) {
+func TestGetStatuses(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()
 
@@ -147,7 +202,7 @@ func TestGetProjectStatuses(t *testing.T) {
 		}
 	})
 
-	projectStatuses, err := client.GetProjectStatuses(1)
+	projectStatuses, err := client.GetStatuses(1)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 		return
@@ -167,7 +222,7 @@ func TestGetProjectStatusesFailed(t *testing.T) {
 		w.WriteHeader(http.StatusInternalServerError)
 	})
 
-	if _, err := client.GetProjectStatuses(1); err == nil {
+	if _, err := client.GetStatuses(1); err == nil {
 		t.Fatal("expected an error but got none")
 	}
 }
@@ -176,7 +231,7 @@ func TestGetProjectStatusesWithInvalidProjectIDOrKeyFailed(t *testing.T) {
 	client, _, _, teardown := setup()
 	defer teardown()
 
-	if _, err := client.GetProjectStatuses(true); err == nil {
+	if _, err := client.GetStatuses(true); err == nil {
 		t.Fatal("expected an error but got none")
 	}
 }
@@ -381,6 +436,626 @@ func TestDeleteProjectWithInvalidProjectIDOrKeyFailed(t *testing.T) {
 	defer teardown()
 
 	if _, err := client.DeleteProject(true); err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetProjectIcon(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	client.httpclient = &mockHTTPClient{}
+
+	err := client.GetProjectIcon("SRE", &bytes.Buffer{})
+	if err != nil {
+		log.Fatalf("Unexpected error: %s in test", err)
+	}
+}
+
+func TestGetProjectIconFailed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("//projects/SRE/image", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	if err := client.GetProjectIcon("SRE", &bytes.Buffer{}); err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetProjectIconInvalidProjectKey(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	if err := client.GetProjectIcon("%", &bytes.Buffer{}); err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestAddProjectUser(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/projects/SRE/users", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, testJSONUser); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.AddProjectUser("SRE", &AddProjectUserInput{
+		UserID: Int(1),
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := getTestUser()
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestAddProjectUserFailed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/projects/SRE/users", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.AddProjectUser("SRE", &AddProjectUserInput{
+		UserID: Int(1),
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestAddProjectUserInvalidProjectKey(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	_, err := client.AddProjectUser("%", &AddProjectUserInput{
+		UserID: Int(1),
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetProjectUsers(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/projects/SRE/users", func(w http.ResponseWriter, r *http.Request) {
+		j := fmt.Sprintf("[%s]", testJSONUser)
+		if _, err := fmt.Fprint(w, j); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetProjectUsers("SRE", &GetProjectUsersOptions{
+		ExcludeGroupMembers: Bool(false),
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := []*User{getTestUser()}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetProjectUsersFailed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/projects/SRE/users", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetProjectUsers("SRE", &GetProjectUsersOptions{
+		ExcludeGroupMembers: Bool(false),
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetProjectUsersInvalidProjectKey(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	_, err := client.GetProjectUsers("%", &GetProjectUsersOptions{
+		ExcludeGroupMembers: Bool(false),
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestDeleteProjectUser(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/projects/SRE/users", func(w http.ResponseWriter, r *http.Request) {
+		j := fmt.Sprintf("%s", testJSONUser)
+		if _, err := fmt.Fprint(w, j); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.DeleteProjectUser("SRE", &DeleteProjectUserInput{
+		UserID: Int(1),
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := getTestUser()
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestDeleteProjectUserFailed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/projects/SRE/users", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.DeleteProjectUser("SRE", &DeleteProjectUserInput{
+		UserID: Int(1),
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestDeleteProjectUserInvalidProjectKey(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	_, err := client.DeleteProjectUser("%", &DeleteProjectUserInput{
+		UserID: Int(1),
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestAddProjectAdministrator(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/projects/SRE/administrators", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, testJSONUser); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.AddProjectAdministrator("SRE", &AddProjectAdministratorInput{
+		UserID: Int(1),
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := getTestUser()
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestAddProjectAdministratorFailed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/projects/SRE/administrators", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.AddProjectAdministrator("SRE", &AddProjectAdministratorInput{
+		UserID: Int(1),
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestAddProjectAdministratorInvalidProjectKey(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	_, err := client.AddProjectAdministrator("%", &AddProjectAdministratorInput{
+		UserID: Int(1),
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetProjectAdministrators(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/projects/SRE/administrators", func(w http.ResponseWriter, r *http.Request) {
+		j := fmt.Sprintf(`[%s]`, testJSONUser)
+		if _, err := fmt.Fprint(w, j); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetProjectAdministrators("SRE")
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := []*User{getTestUser()}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetProjectAdministratorsFailed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/projects/SRE/administrators", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetProjectAdministrators("SRE")
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetProjectAdministratorsInvalidProjectKey(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	_, err := client.GetProjectAdministrators("%")
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestDeleteProjectAdministrator(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/projects/SRE/administrators", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, testJSONUser); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.DeleteProjectAdministrator("SRE", &DeleteProjectAdministratorInput{
+		UserID: Int(1),
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := getTestUser()
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestDeleteProjectAdministratorFailed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/projects/SRE/administrators", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.DeleteProjectAdministrator("SRE", &DeleteProjectAdministratorInput{
+		UserID: Int(1),
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestDeleteProjectAdministratorInvalidProjectKey(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	_, err := client.DeleteProjectAdministrator("%", &DeleteProjectAdministratorInput{
+		UserID: Int(1),
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestCreateStatus(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/projects/SRE/statuses", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, testJSONProjectStatus); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.CreateStatus("SRE", &CreateStatusInput{
+		Name:  String("未対応"),
+		Color: String("#ed8077"),
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := getTestProjectStatus()
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestCreateStatusFailed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/projects/SRE/statuses", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.CreateStatus("SRE", &CreateStatusInput{
+		Name:  String("未対応"),
+		Color: String("#ed8077"),
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestCreateStatusInvalidProjectKey(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	_, err := client.CreateStatus("%", &CreateStatusInput{
+		Name:  String("未対応"),
+		Color: String("#ed8077"),
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestUpdateStatus(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/projects/SRE/statuses/1", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, testJSONProjectStatus); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.UpdateStatus("SRE", 1, &UpdateStatusInput{
+		Name:  String("未対応"),
+		Color: String("#ed8077"),
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := getTestProjectStatus()
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestUpdateStatusFailed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/projects/SRE/statuses", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.UpdateStatus("SRE", 1, &UpdateStatusInput{
+		Name:  String("未対応"),
+		Color: String("#ed8077"),
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestUpdateStatusInvalidProjectKey(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	_, err := client.UpdateStatus("%", 1, &UpdateStatusInput{
+		Name:  String("未対応"),
+		Color: String("#ed8077"),
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestDeleteStatus(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/projects/SRE/statuses/1", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, testJSONProjectStatus); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.DeleteStatus("SRE", 1, &DeleteStatusInput{
+		SubstituteStatusID: Int(1),
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := getTestProjectStatus()
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestDeleteStatusFailed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/projects/SRE/statuses", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.DeleteStatus("SRE", 1, &DeleteStatusInput{
+		SubstituteStatusID: Int(1),
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestDeleteStatusInvalidProjectKey(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	_, err := client.DeleteStatus("%", 1, &DeleteStatusInput{
+		SubstituteStatusID: Int(1),
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestSortStatuses(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/projects/SRE/statuses/updateDisplayOrder", func(w http.ResponseWriter, r *http.Request) {
+		j := fmt.Sprintf(`[%s]`, testJSONProjectStatus)
+		if _, err := fmt.Fprint(w, j); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.SortStatuses("SRE", &SortStatusesInput{
+		StatusIDs: []int{1},
+	})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := []*Status{getTestProjectStatus()}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestSortStatusesFailed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/projects/SRE/statuses", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.SortStatuses("SRE", &SortStatusesInput{
+		StatusIDs: []int{1},
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestSortStatusesInvalidProjectKey(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	_, err := client.SortStatuses("%", &SortStatusesInput{
+		StatusIDs: []int{1},
+	})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetProjectDiskUsage(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/projects/SRE/diskUsage", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, `{
+			"projectId": 1,
+			"issue": 11931,
+			"wiki": 0,
+			"file": 0,
+			"subversion": 0,
+			"git": 0,
+			"gitLFS": 0
+		}`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.GetProjectDiskUsage("SRE")
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := &ProjectDiskUsage{
+		ProjectID:  Int(1),
+		Issue:      Int(11931),
+		Wiki:       Int(0),
+		File:       Int(0),
+		Subversion: Int(0),
+		Git:        Int(0),
+		GitLFS:     Int(0),
+	}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestGetProjectDiskUsageFailed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/projects/SRE/diskUsage", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.GetProjectDiskUsage("SRE")
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetProjectDiskUsageInvalidProjectKey(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	_, err := client.GetProjectDiskUsage("%")
+	if err == nil {
 		t.Fatal("expected an error but got none")
 	}
 }

--- a/user.go
+++ b/user.go
@@ -69,17 +69,6 @@ type User struct {
 	MailAddress *string  `json:"mailAddress,omitempty"`
 }
 
-// Activity : activity
-type Activity struct {
-	ID            *int            `json:"id,omitempty"` // User.ID
-	Project       *Project        `json:"project,omitempty"`
-	Type          *int            `json:"type,omitempty"`
-	Content       *Content        `json:"content,omitempty"`
-	Notifications []*Notification `json:"notifications,omitempty"`
-	CreatedUser   *User           `json:"createdUser,omitempty"`
-	Created       *Timestamp      `json:"created,omitempty"`
-}
-
 // Notification : -
 type Notification struct {
 	ID                  *int  `json:"id,omitempty"`
@@ -266,32 +255,6 @@ func (c *Client) GetUserIconContext(ctx context.Context, id int, writer io.Write
 	return nil
 }
 
-// GetUserActivities returns the list of a user's activities
-func (c *Client) GetUserActivities(id int, opts *GetUserActivitiesOptions) ([]*Activity, error) {
-	return c.GetUserActivitiesContext(context.Background(), id, opts)
-}
-
-// GetUserActivitiesContext returns the list of a user's activities with context
-func (c *Client) GetUserActivitiesContext(ctx context.Context, id int, opts *GetUserActivitiesOptions) ([]*Activity, error) {
-	u := fmt.Sprintf("/api/v2/users/%v/activities", id)
-
-	u, err := c.AddOptions(u, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := c.NewRequest("GET", u, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	var activities []*Activity
-	if err := c.Do(ctx, req, &activities); err != nil {
-		return nil, err
-	}
-	return activities, nil
-}
-
 // GetUserStars returns the list of stared contents
 func (c *Client) GetUserStars(id int, opts *GetUserStarsOptions) ([]*Star, error) {
 	return c.GetUserStarsContext(context.Background(), id, opts)
@@ -359,15 +322,6 @@ type UpdateUserInput struct {
 	Name        *string
 	MailAddress *string
 	RoleType    RoleType
-}
-
-// GetUserActivitiesOptions specifies parameters to the GetUserActivities method.
-type GetUserActivitiesOptions struct {
-	ActivityTypeIDs []int `url:"activityTypeId[],omitempty"`
-	MinID           *int  `url:"minId,omitempty"`
-	MaxID           *int  `url:"maxId,omitempty"`
-	Count           *int  `url:"count,omitempty"`
-	Order           Order `url:"order,omitempty"`
 }
 
 // GetUserStarsOptions specifies parameters to the GetUserStars method.

--- a/user_test.go
+++ b/user_test.go
@@ -18,71 +18,6 @@ const testJSONUser string = `{
 	"mailAddress": "eguchi@nulab.example"
 }`
 
-const testJSONActivity string = `{
-	"id": 1,
-	"project": {
-		"id": 92,
-		"projectKey": "SUB",
-		"name": "サブタスク",
-		"chartEnabled": true,
-		"subtaskingEnabled": true,
-		"projectLeaderCanEditProjectLeader": false,
-		"textFormattingRule": "",
-		"archived": false,
-		"displayOrder": 0
-	},
-	"type": 2,
-	"content": {
-		"id": 4809,
-		"key_id": 121,
-		"summary": "コメント",
-		"description": "",
-		"comment": {
-			"id": 7237,
-			"content": ""
-		},
-		"changes": [
-			{
-				"field": "milestone",
-				"new_value": " R2014-07-23",
-				"old_value": "",
-				"type": "standard"
-			},
-			{
-				"field": "status",
-				"new_value": "4",
-				"old_value": "1",
-				"type": "standard"
-			}
-		]
-	},
-	"notifications": [
-		{
-			"id": 25,
-			"alreadyRead": false,
-			"reason": 2,
-			"user": {
-				"id": 5686,
-				"userId": "takada",
-				"name": "takada",
-				"roleType": 2,
-				"lang": "ja",
-				"mailAddress": "takada@nulab.example"
-			},
-			"resourceAlreadyRead": false
-		}
-	],
-	"createdUser": {
-		"id": 1,
-		"userId": "admin",
-		"name": "admin",
-		"roleType": 1,
-		"lang": "ja",
-		"mailAddress": "eguchi@nulab.example"
-	},
-	"created": "2006-01-02T15:04:05Z"
-}`
-
 const testJSONStar string = `{
 	"id": 1,
 	"comment": "",
@@ -193,7 +128,7 @@ func getTestUser() *User {
 	}
 }
 
-func getTestUserActivity() *Activity {
+func getTestActivity() *Activity {
 	return &Activity{
 		ID: Int(1),
 		Project: &Project{
@@ -525,51 +460,6 @@ func TestGetUserIcon(t *testing.T) {
 	err := client.GetUserIcon(1, &bytes.Buffer{})
 	if err != nil {
 		log.Fatalf("Unexpected error: %s in test", err)
-	}
-}
-
-func TestGetUserActivities(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/users/1/activities", func(w http.ResponseWriter, r *http.Request) {
-		j := fmt.Sprintf("[%s]", testJSONActivity)
-		if _, err := fmt.Fprint(w, j); err != nil {
-			t.Fatal(err)
-		}
-	})
-
-	input := &GetUserActivitiesOptions{
-		ActivityTypeIDs: []int{1, 2, 3},
-		MinID:           Int(1),
-		MaxID:           Int(10),
-		Count:           Int(20),
-		Order:           OrderAsc,
-	}
-	activities, err := client.GetUserActivities(1, input)
-	if err != nil {
-		t.Errorf("Unexpected error: %s", err)
-		return
-	}
-
-	want := []*Activity{getTestUserActivity()}
-
-	if !reflect.DeepEqual(want, activities) {
-		t.Fatal(ErrIncorrectResponse)
-	}
-}
-
-func TestGetUserActivitiesFailed(t *testing.T) {
-	client, mux, _, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/users/1/activities", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	})
-
-	input := &GetUserActivitiesOptions{}
-	if _, err := client.GetUserActivities(1, input); err == nil {
-		t.Fatal("expected an error but got none")
 	}
 }
 


### PR DESCRIPTION
Support backlog API the below:

* GET		/api/v2/users/myself/recentlyViewedProjects
* GET		/api/v2/projects/:projectIdOrKey/image
* POST		/api/v2/projects/:projectIdOrKey/users
* GET		/api/v2/projects/:projectIdOrKey/users
* DELETE	/api/v2/projects/:projectIdOrKey/users
* POST		/api/v2/projects/:projectIdOrKey/administrators
* GET		/api/v2/projects/:projectIdOrKey/administrators
* DELETE	/api/v2/projects/:projectIdOrKey/administrators
* POST		/api/v2/projects/:projectIdOrKey/statuses
* PATCH		/api/v2/projects/:projectIdOrKey/statuses/:id
* DELETE	/api/v2/projects/:projectIdOrKey/statuses/:id
* PATCH		/api/v2/projects/:projectIdOrKey/statuses/updateDisplayOrder
* GET		/api/v2/projects/:projectIdOrKey/diskUsage
* GET		/api/v2/projects/:projectIdOrKey/activities

And add unit tests for them.