### PR TITLE
Support delete an attachment in a wiki API

### DIFF
--- a/issue_test.go
+++ b/issue_test.go
@@ -115,11 +115,11 @@ var testJSONIssueComment string = fmt.Sprintf(`{
 }`, testJSONUser, testJSONNotification)
 
 var testJSONAttachment string = fmt.Sprintf(`{
-	"id":8,
-	"name":"IMG0088.png",
-	"size":5563,
+	"id": 1,
+	"name": "Duke.png",
+	"size": 196186,
 	"createdUser": %v,
-	"created":"2006-01-02T15:04:05Z"
+	"created": "2006-01-02T15:04:05Z"
 }`, testJSONUser)
 
 func getTestIssue() *Issue {
@@ -221,9 +221,9 @@ func getTestNotification() *Notification {
 
 func getTestAttachment() *Attachment {
 	return &Attachment{
-		ID:          Int(8),
-		Name:        String("IMG0088.png"),
-		Size:        Int(5563),
+		ID:          Int(1),
+		Name:        String("Duke.png"),
+		Size:        Int(196186),
 		CreatedUser: getTestUser(),
 		Created:     &Timestamp{referenceTime},
 	}

--- a/wiki.go
+++ b/wiki.go
@@ -293,6 +293,27 @@ func (c *Client) AddAttachmentToWikiContext(ctx context.Context, wikiID int, inp
 	return attachments, nil
 }
 
+// DeleteAttachmentInWiki deletes a attachment in a wiki
+func (c *Client) DeleteAttachmentInWiki(wikiID, attachmentID int) (*Attachment, error) {
+	return c.DeleteAttachmentInWikiContext(context.Background(), wikiID, attachmentID)
+}
+
+// DeleteAttachmentInWikiContext deletes a attachment in a wiki with context
+func (c *Client) DeleteAttachmentInWikiContext(ctx context.Context, wikiID, attachmentID int) (*Attachment, error) {
+	u := fmt.Sprintf("/api/v2/wikis/%v/attachments/%v", wikiID, attachmentID)
+
+	req, err := c.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	attachment := new(Attachment)
+	if err := c.Do(ctx, req, &attachment); err != nil {
+		return nil, err
+	}
+	return attachment, nil
+}
+
 // GetMyRecentlyViewedWikisOptions specifies parameters to the GetMyRecentlyViewedWikis method.
 type GetMyRecentlyViewedWikisOptions struct {
 	Order  Order `url:"order,omitempty"`


### PR DESCRIPTION
Support backlog API the below:

* DELETE /api/v2/wikis/:wikiId/attachments/:attachmentId

And integrate a test value of attachment.