### PR TITLE
Allow to update the values to integer or an empty string on update issue API

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -771,22 +771,34 @@ type CreateIssueInput struct {
 }
 
 // UpdateIssueInput specifies parameters to the UpdateIssue method.
+//
+// The following values ​​are updated as integer or an empty string:
+// - resolutionId
+// - estimatedHours
+// - actualHours
+// - assigneeId
+//
+// ex. update `estimatedHours` to 10
+// - UpdateIssue("EX-1", &UpdateIssueInput{ EstimatedHours: Int(10) })
+//
+// ex. update `estimatedHours` to an empty string
+// - UpdateIssue("EX-1", &UpdateIssueInput{ EstimatedHours: String("") })
 type UpdateIssueInput struct {
 	Summary         *string             `json:"summary,omitempty"`
 	ParentIssueID   *int                `json:"parentIssueId,omitempty"`
 	Description     *string             `json:"description,omitempty"`
 	StatusID        *int                `json:"statusId,omitempty"`
-	ResolutionID    *int                `json:"resolutionId,omitempty"`
+	ResolutionID    interface{}         `json:"resolutionId,omitempty"`
 	StartDate       *string             `json:"startDate,omitempty"`
 	DueDate         *string             `json:"dueDate,omitempty"`
-	EstimatedHours  *int                `json:"estimatedHours,omitempty"`
-	ActualHours     *int                `json:"actualHours,omitempty"`
+	EstimatedHours  interface{}         `json:"estimatedHours,omitempty"`
+	ActualHours     interface{}         `json:"actualHours,omitempty"`
 	IssueTypeID     *int                `json:"issueTypeId,omitempty"`
 	CategoryIDs     []int               `json:"categoryId,omitempty"`
 	VersionIDs      []int               `json:"versionId,omitempty"`
 	MilestoneIDs    []int               `json:"milestoneId,omitempty"`
 	PriorityID      *int                `json:"priorityId,omitempty"`
-	AssigneeID      *int                `json:"assigneeId,omitempty"`
+	AssigneeID      interface{}         `json:"assigneeId,omitempty"`
 	NotifiedUserIDs []int               `json:"notifiedUserId,omitempty"`
 	AttachmentIDs   []int               `json:"attachmentId,omitempty"`
 	Comment         *string             `json:"comment,omitempty"`

--- a/issue_test.go
+++ b/issue_test.go
@@ -695,7 +695,8 @@ func TestUpdateIssue(t *testing.T) {
 	})
 
 	expected, err := client.UpdateIssue("BLG-1", &UpdateIssueInput{
-		Summary: String("first issue"),
+		Summary:        String("first issue"),
+		EstimatedHours: String(""), // set empty value
 		CustomFields: []*IssueCustomField{
 			{
 				ID:          Int(111),


### PR DESCRIPTION
related issue: https://github.com/kenzo0107/backlog/issues/40

The following values ​​are updated as integer or an empty string:
- resolutionId
- estimatedHours
- actualHours
- assigneeId

ex. update `estimatedHours` to 10
```
UpdateIssue("EX-1", &UpdateIssueInput{ EstimatedHours: Int(10) })
```

ex. update `estimatedHours` to an empty string
```
UpdateIssue("EX-1", &UpdateIssueInput{ EstimatedHours: String("") })
```