### PR TITLE
Convert int to float64

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -96,8 +96,8 @@ type Issue struct {
 	Milestone      []*Milestone        `json:"milestone,omitempty"`
 	StartDate      *string             `json:"startDate,omitempty"`
 	DueDate        *string             `json:"dueDate,omitempty"`
-	EstimatedHours *int                `json:"estimatedHours,omitempty"`
-	ActualHours    *int                `json:"actualHours,omitempty"`
+	EstimatedHours *float64            `json:"estimatedHours,omitempty"`
+	ActualHours    *float64            `json:"actualHours,omitempty"`
 	ParentIssueID  *int                `json:"parentIssueId,omitempty"`
 	CreatedUser    *User               `json:"createdUser,omitempty"`
 	Created        *Timestamp          `json:"created,omitempty"`
@@ -757,8 +757,8 @@ type CreateIssueInput struct {
 	Description     *string             `json:"description,omitempty"`
 	StartDate       *string             `json:"startDate,omitempty"`
 	DueDate         *string             `json:"dueDate,omitempty"`
-	EstimatedHours  *int                `json:"estimatedHours,omitempty"`
-	ActualHours     *int                `json:"actualHours,omitempty"`
+	EstimatedHours  *float64            `json:"estimatedHours,omitempty"`
+	ActualHours     *float64            `json:"actualHours,omitempty"`
 	IssueTypeID     *int                `json:"issueTypeId"`
 	CategoryIDs     []int               `json:"categoryId,omitempty"`
 	VersionIDs      []int               `json:"versionId,omitempty"`


### PR DESCRIPTION
素晴らしいライブラリをありがとうございます。

予定時間、実績時間に小数を入力されたIssueを取得した場合、エラーが発生しました。
```
{
  "errorMessage": "json: cannot unmarshal number 0.5 into Go struct field Issue.actualHours of type int",
  "errorType": "UnmarshalTypeError"
}
```

intで定義されていますので、float64に変更しました。
ご確認よろしくお願い致します。