### PR TITLE
rateLimitとwikiのattachmentのcontentsを取得する機能を追加

### DIFF
--- a/rate_limit.go
+++ b/rate_limit.go
@@ -1,0 +1,51 @@
+package backlog
+
+import (
+	"context"
+	"time"
+)
+
+// LimitStatus : limit status
+type LimitStatus struct {
+	Limit     *int `json:"limit,omitempty"`
+	Remaining *int `json:"remaining,omitempty"`
+	Reset     *int `json:"reset,omitempty"`
+}
+
+func (ls *LimitStatus) ResetAsTime() time.Time {
+	if ls.Reset == nil {
+		return time.Time{}
+	}
+	return time.Unix(int64(*ls.Reset), 0)
+}
+
+// RateLimit : rate limit
+type RateLimit struct {
+	Read   *LimitStatus `json:"read,omitempty"`
+	Update *LimitStatus `json:"update,omitempty"`
+	Search *LimitStatus `json:"search,omitempty"`
+	Icon   *LimitStatus `json:"icon,omitempty"`
+}
+
+// GetRateLimit returns the rate limit
+func (c *Client) GetRateLimit() (*RateLimit, error) {
+	return c.GetRateLimitContext(context.Background())
+}
+
+// GetWikisContext returns the rate limit
+func (c *Client) GetRateLimitContext(ctx context.Context) (*RateLimit, error) {
+	u := "/api/v2/rateLimit"
+
+	req, err := c.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	wrapper := new(struct {
+		RateLimit *RateLimit `json:"rateLimit,omitempty"`
+	})
+	if err := c.Do(ctx, req, &wrapper); err != nil {
+		return nil, err
+	}
+	return wrapper.RateLimit, nil
+}

--- a/wiki.go
+++ b/wiki.go
@@ -3,6 +3,7 @@ package backlog
 import (
 	"context"
 	"fmt"
+	"io"
 )
 
 // Wiki : wiki
@@ -270,6 +271,26 @@ func (c *Client) GetWikiAttachmentsContext(ctx context.Context, wikiID int) ([]*
 		return nil, err
 	}
 	return attachments, nil
+}
+
+// GetWikiAttachmentContent writes the content to writer
+func (c *Client) GetWikiAttachmentContent(wikiID, attachmentID int, w io.Writer) error {
+	return c.GetWikiAttachmentContentContext(context.Background(), wikiID, attachmentID, w)
+}
+
+// GetWikiAttachmentContentContext writes the content to writer
+func (c *Client) GetWikiAttachmentContentContext(ctx context.Context, wikiID, attachmentID int, w io.Writer) error {
+	u := fmt.Sprintf("/api/v2/wikis/%v/attachments/%v", wikiID, attachmentID)
+
+	req, err := c.NewRequest("GET", u, nil)
+	if err != nil {
+		return err
+	}
+
+	if err := c.Do(ctx, req, w); err != nil {
+		return err
+	}
+	return nil
 }
 
 // AddAttachmentToWiki adds attachments to a wiki


### PR DESCRIPTION
[rateLimit](https://developer.nulab.com/ja/docs/backlog/rate-limit/#) と [wikiのattachmentのcontents](https://developer.nulab.com/ja/docs/backlog/api/2/get-wiki-page-attachment/#wiki%E6%B7%BB%E4%BB%98%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E3%81%AE%E3%83%80%E3%82%A6%E3%83%B3%E3%83%AD%E3%83%BC%E3%83%89) を取得する機能を追加しました。

（テストコードは作成していません。）
