### PR TITLE
Support get-wiki-page-attachment API

### DIFF
--- a/wiki.go
+++ b/wiki.go
@@ -3,6 +3,7 @@ package backlog
 import (
 	"context"
 	"fmt"
+	"io"
 )
 
 // Wiki : wiki
@@ -270,6 +271,26 @@ func (c *Client) GetWikiAttachmentsContext(ctx context.Context, wikiID int) ([]*
 		return nil, err
 	}
 	return attachments, nil
+}
+
+// GetWikiAttachmentContent writes the content to writer
+func (c *Client) GetWikiAttachmentContent(wikiID, attachmentID int, w io.Writer) error {
+	return c.GetWikiAttachmentContentContext(context.Background(), wikiID, attachmentID, w)
+}
+
+// GetWikiAttachmentContentContext writes the content to writer
+func (c *Client) GetWikiAttachmentContentContext(ctx context.Context, wikiID, attachmentID int, w io.Writer) error {
+	u := fmt.Sprintf("/api/v2/wikis/%v/attachments/%v", wikiID, attachmentID)
+
+	req, err := c.NewRequest("GET", u, nil)
+	if err != nil {
+		return err
+	}
+
+	if err := c.Do(ctx, req, w); err != nil {
+		return err
+	}
+	return nil
 }
 
 // AddAttachmentToWiki adds attachments to a wiki

--- a/wiki_test.go
+++ b/wiki_test.go
@@ -1,6 +1,7 @@
 package backlog
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -553,6 +554,32 @@ func TestGetWikiAttachmentsFailed(t *testing.T) {
 	})
 
 	if _, err := client.GetWikiAttachments(1); err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestGetWikiAttachmentContent(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	client.httpclient = &mockHTTPClient{}
+
+	err := client.GetWikiAttachmentContent(1, 1, &bytes.Buffer{})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+}
+
+func TestGetWikiAttachmentContentFailed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/wikis/1/attachments/2", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	if err := client.GetWikiAttachmentContent(1, 2, &bytes.Buffer{}); err == nil {
 		t.Fatal("expected an error but got none")
 	}
 }


### PR DESCRIPTION
Support backlog API the below:

- GET /api/v2/wikis/:wikiId/attachments/:attachmentId ref: https://developer.nulab.com/ja/docs/backlog/api/2/get-wiki-page-attachment/#wiki添付ファイルのダウンロード