### PR TITLE
Get reset as time in rate limit API

### DIFF
--- a/rate_limit.go
+++ b/rate_limit.go
@@ -2,6 +2,7 @@ package backlog
 
 import (
 	"context"
+	"time"
 )
 
 // LimitStatus : limit status
@@ -9,6 +10,14 @@ type LimitStatus struct {
 	Limit     *int `json:"limit,omitempty"`
 	Remaining *int `json:"remaining,omitempty"`
 	Reset     *int `json:"reset,omitempty"`
+}
+
+// ResetAsTime returns reset as time
+func (ls *LimitStatus) ResetAsTime() time.Time {
+	if ls.Reset == nil {
+		return time.Time{}
+	}
+	return time.Unix(int64(*ls.Reset), 0)
 }
 
 // RateLimit : rate limit

--- a/rate_limit_test.go
+++ b/rate_limit_test.go
@@ -5,7 +5,31 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+	"time"
+
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/pkg/errors"
 )
+
+func TestResetAsTime(t *testing.T) {
+	ls := &LimitStatus{
+		Reset: Int(1603881873),
+	}
+	expected := ls.ResetAsTime().UTC()
+	want := time.Date(2020, time.October, 28, 10, 44, 33, 0, time.UTC)
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestResetAsTimeWithResetNull(t *testing.T) {
+	ls := &LimitStatus{}
+	expected := ls.ResetAsTime()
+	want := time.Time{}
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(errors.New(pretty.Compare(want, expected)))
+	}
+}
 
 const testJSONRateLimit string = `{
 	"rateLimit": {


### PR DESCRIPTION
Return the timestamp of the reset of the API to get the rate limit as time.Time type. 
Time type to facilitate time comparisons.