### PR TITLE
Support deleting issue API

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -366,6 +366,27 @@ func (c *Client) UpdateIssueContext(ctx context.Context, issueIDOrKey string, in
 	return issue, nil
 }
 
+// DeleteIssue deletes an issue
+func (c *Client) DeleteIssue(issueIDOrKey string) (*Issue, error) {
+	return c.DeleteIssueContext(context.Background(), issueIDOrKey)
+}
+
+// DeleteIssueContext deletes an issue with context
+func (c *Client) DeleteIssueContext(ctx context.Context, issueIDOrKey string) (*Issue, error) {
+	u := fmt.Sprintf("/api/v2/issues/%v", issueIDOrKey)
+
+	req, err := c.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	issue := new(Issue)
+	if err := c.Do(ctx, req, &issue); err != nil {
+		return nil, err
+	}
+	return issue, nil
+}
+
 // GetIssueComments get list of the issue comments
 func (c *Client) GetIssueComments(issueIDOrKey string, opts *GetIssueCommentsOptions) ([]*IssueComment, error) {
 	return c.GetIssueCommentsContext(context.Background(), issueIDOrKey, opts)

--- a/issue_test.go
+++ b/issue_test.go
@@ -768,6 +768,52 @@ func TestUpdateIssueInvalidIssueKey(t *testing.T) {
 	}
 }
 
+func TestDeleteIssue(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/issues/BLG-1", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fmt.Fprint(w, testJSONIssue); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	expected, err := client.DeleteIssue("BLG-1")
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+		return
+	}
+
+	want := getTestIssue()
+	if !reflect.DeepEqual(want, expected) {
+		t.Fatal(ErrIncorrectResponse, errors.New(pretty.Compare(want, expected)))
+	}
+}
+
+func TestDeleteIssueFailed(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/issues/BLG-1", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.DeleteIssue("BLG-1")
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
+func TestDeleteIssueInvalidIssueKey(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	_, err := client.DeleteIssue("%")
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+}
+
 func TestGetIssueComments(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()


### PR DESCRIPTION
課題の削除に対応してみました。
他のテストを参考にテストコードも埋めてみました。
手元でBacklog上の課題を消す動作も確認しています。
ご確認をお願いいたします。

DELETE /api/v2/ issues/:issueIdOrKey
ref: https://developer.nulab.com/ja/docs/backlog/api/2/delete-issue/