### PR TITLE
Pin the GitHub Actions version using a commit hash

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,13 +21,13 @@ jobs:
           - ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Pick terraform_version
         id: golang
         run: echo "version=$(awk '$1 ~ /^golang/{print $2}' .tool-versions)" >> $GITHUB_OUTPUT
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version: ${{ steps.golang.outputs.version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,11 @@ jobs:
       RELEASE_IT_VERSION: 15.6.0
     steps:
       - name: Check out codes
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: '19'
       - name: Set releaser settings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,13 @@ jobs:
           - ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Pick go_version
         id: golang
         run: echo "version=$(awk '$1 ~ /^golang/{print $2}' .tool-versions)" >> $GITHUB_OUTPUT
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version: ${{ steps.golang.outputs.version }}
 


### PR DESCRIPTION
This is a fix that considers the impact of the following issues:

https://www.wiz.io/blog/new-github-action-supply-chain-attack-reviewdog-action-setup
> A supply chain attack on tj-actions/changed-files caused many repositories to leak their secrets over the weekend. Wiz Research has discovered an additional supply chain attack on reviewdog/actions-setup@v1, that may have contributed to the compromise of tj-actions/changed-files.