### PR TITLE
Added error testing for `c.NewRequest` across all APIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test-integration:
 
 ## Output coverage of testing
 cov:
-	@go test -count 1 -coverprofile=cover.out ./... | grep -v "examples/"
+	@go test -count 1 -coverprofile=cover.out $$(go list ./... | grep -v examples)
 	@go tool cover -html=cover.out
 .PHONY: cov
 

--- a/activity_test.go
+++ b/activity_test.go
@@ -3,7 +3,9 @@ package backlog
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/kylelemons/godebug/pretty"
@@ -164,4 +166,42 @@ func TestGetProjectActivitiesInvalidProjectKey(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error but got none")
 	}
+}
+
+func TestGetUserActivities_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://example.com/api/v2/")
+	client.baseURL = invalidURL
+
+	_, err := client.GetUserActivities(1, &GetUserActivitiesOptions{})
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
+}
+
+func TestGetProjectActivities_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://example.com/api/v2/")
+	client.baseURL = invalidURL
+
+	_, err := client.GetProjectActivities("SRE", &GetProjectActivitiesOptions{})
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
 }

--- a/category_test.go
+++ b/category_test.go
@@ -3,7 +3,9 @@ package backlog
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/kylelemons/godebug/pretty"
@@ -219,4 +221,80 @@ func TestDeleteCategoryInvalidProjectKey(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error but got none")
 	}
+}
+
+func TestGetCategories_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://example.com/api/v2/")
+	client.baseURL = invalidURL
+
+	_, err := client.GetCategories("SRE")
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
+}
+
+func TestCreateCategory_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://example.com/api/v2/")
+	client.baseURL = invalidURL
+
+	_, err := client.CreateCategory("SRE", &CreateCategoryInput{Name: String("test")})
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
+}
+
+func TestUpdateCategory_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://example.com/api/v2/")
+	client.baseURL = invalidURL
+
+	_, err := client.UpdateCategory("SRE", 1, &UpdateCategoryInput{Name: String("test")})
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
+}
+
+func TestDeleteCategory_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://example.com/api/v2/")
+	client.baseURL = invalidURL
+
+	_, err := client.DeleteCategory("SRE", 1)
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
 }

--- a/customfield_test.go
+++ b/customfield_test.go
@@ -3,7 +3,9 @@ package backlog
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/kylelemons/godebug/pretty"
@@ -91,4 +93,23 @@ func TestGetCustomFieldsInvalidProjectKey(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error but got none")
 	}
+}
+
+func TestGetCustomFields_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://example.com/api/v2/")
+	client.baseURL = invalidURL
+
+	_, err := client.GetCustomFields("SRE")
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
 }

--- a/git_test.go
+++ b/git_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -212,4 +214,42 @@ func TestGetGitRepositoryContext(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
+}
+
+func TestGetGitRepositories_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://example.com/api/v2/")
+	client.baseURL = invalidURL
+
+	_, err := client.GetGitRepositories("TEST")
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
+}
+
+func TestGetGitRepository_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://example.com/api/v2/")
+	client.baseURL = invalidURL
+
+	_, err := client.GetGitRepository("TEST", "test-repo")
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
 }

--- a/priority_test.go
+++ b/priority_test.go
@@ -3,7 +3,9 @@ package backlog
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/kylelemons/godebug/pretty"
@@ -56,4 +58,23 @@ func TestGetPrioritiesFailed(t *testing.T) {
 	if _, err := client.GetPriorities(); err == nil {
 		t.Fatal("expected an error but got none")
 	}
+}
+
+func TestGetPriorities_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://example.com/api/v2/")
+	client.baseURL = invalidURL
+
+	_, err := client.GetPriorities()
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
 }

--- a/pullrequest_test.go
+++ b/pullrequest_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -376,4 +378,23 @@ func TestUpdatePullRequest(t *testing.T) {
 	if !reflect.DeepEqual(pullRequest, want) {
 		t.Fatal(errors.Errorf("Response is incorrect: %s", pretty.Compare(pullRequest, want)))
 	}
+}
+
+func TestGetPullRequests_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://example.com/api/v2/")
+	client.baseURL = invalidURL
+
+	_, err := client.GetPullRequests("TEST", "test-repo", &GetPullRequestsOptions{})
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
 }

--- a/rate_limit_test.go
+++ b/rate_limit_test.go
@@ -3,7 +3,9 @@ package backlog
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -117,4 +119,23 @@ func TestGetRateLimitFailed(t *testing.T) {
 	if _, err := client.GetRateLimit(); err == nil {
 		t.Fatal("expected an error but got none")
 	}
+}
+
+func TestGetRateLimit_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://example.com/api/v2/")
+	client.baseURL = invalidURL
+
+	_, err := client.GetRateLimit()
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
 }

--- a/resolution_test.go
+++ b/resolution_test.go
@@ -3,7 +3,9 @@ package backlog
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/kylelemons/godebug/pretty"
@@ -50,4 +52,23 @@ func TestGetResolutionsFailed(t *testing.T) {
 	if _, err := client.GetResolutions(); err == nil {
 		t.Fatal("expected an error but got none")
 	}
+}
+
+func TestGetResolutions_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://example.com/api/v2/")
+	client.baseURL = invalidURL
+
+	_, err := client.GetResolutions()
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
 }

--- a/space_test.go
+++ b/space_test.go
@@ -6,7 +6,9 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/kylelemons/godebug/pretty"
@@ -368,4 +370,23 @@ func TestGetSpaceLicenseFailed(t *testing.T) {
 	if _, err := client.GetLicence(); err == nil {
 		t.Fatal("expected an error but got none")
 	}
+}
+
+func TestGetSpace_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://example.com/api/v2/")
+	client.baseURL = invalidURL
+
+	_, err := client.GetSpace()
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
 }

--- a/user_test.go
+++ b/user_test.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -542,4 +544,61 @@ func TestGetUserStarCountFailed(t *testing.T) {
 	if _, err := client.GetUserStarCount(1, input); err == nil {
 		t.Fatal("expected an error but got none")
 	}
+}
+
+func TestGetUserMySelf_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://example.com/api/v2/")
+	client.baseURL = invalidURL
+
+	_, err := client.GetUserMySelf()
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
+}
+
+func TestGetUsers_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://example.com/api/v2/")
+	client.baseURL = invalidURL
+
+	_, err := client.GetUsers()
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
+}
+
+func TestCreateUser_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://example.com/api/v2/")
+	client.baseURL = invalidURL
+
+	_, err := client.CreateUser(&CreateUserInput{UserID: String("test"), Password: String("pass"), Name: String("Test User"), MailAddress: String("test@example.com"), RoleType: RoleTypeAdministrator})
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
 }

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -3,7 +3,9 @@ package backlog
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -312,4 +314,42 @@ func TestDeleteWebhookFailed(t *testing.T) {
 	if _, err := client.DeleteWebhook("SRE", 10); err == nil {
 		t.Fatal("expected an error but got none")
 	}
+}
+
+func TestGetWebhooks_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://example.com/api/v2/")
+	client.baseURL = invalidURL
+
+	_, err := client.GetWebhooks("SRE")
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
+}
+
+func TestCreateWebhook_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://example.com/api/v2/")
+	client.baseURL = invalidURL
+
+	_, err := client.CreateWebhook("SRE", &CreateWebhookInput{Name: String("test"), HookURL: String("http://example.com")})
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
 }

--- a/wiki_test.go
+++ b/wiki_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/kylelemons/godebug/pretty"
@@ -659,4 +661,61 @@ func TestDeleteAttachmentInWikiFailed(t *testing.T) {
 	if _, err := client.DeleteAttachmentInWiki(1, 1); err == nil {
 		t.Fatal("expected an error but got none")
 	}
+}
+
+func TestGetWikis_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://example.com/api/v2/")
+	client.baseURL = invalidURL
+
+	_, err := client.GetWikis(&GetWikisOptions{})
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
+}
+
+func TestCreateWiki_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://example.com/api/v2/")
+	client.baseURL = invalidURL
+
+	_, err := client.CreateWiki(&CreateWikiInput{ProjectID: Int(1), Name: String("test"), Content: String("content")})
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
+}
+
+func TestGetWiki_NewRequestError(t *testing.T) {
+	client, _, _, teardown := setup()
+	defer teardown()
+
+	originalBaseURL := client.baseURL
+	invalidURL, _ := url.Parse("https://example.com/api/v2/")
+	client.baseURL = invalidURL
+
+	_, err := client.GetWiki(1)
+	if err == nil {
+		t.Error("Expected error for invalid baseURL")
+	}
+	if err != nil && !strings.Contains(err.Error(), "trailing slash") {
+		t.Errorf("Expected error message to contain 'trailing slash', got %v", err.Error())
+	}
+
+	client.baseURL = originalBaseURL
 }


### PR DESCRIPTION
- Implemented error handling tests for the NewRequest method across all API files
- Configured an invalid baseURL (with a trailing slash) to trigger errors
- Adopted error testing coverage patterns from the sendgrid repository to ensure robustness
- Excluded the examples directory from testing via the Makefile

🤖 Generated with [Claude Code](https://claude.ai/code)